### PR TITLE
Send token without Basic Auth

### DIFF
--- a/amivcore.js
+++ b/amivcore.js
@@ -35,8 +35,9 @@
                         return 'application/json'
                     },
                     'Authorization': function() {
-                        if (get('cur_token') != null)
-                            return 'Basic ' + btoa(get('cur_token') + ':');
+			var token = get('cur_token');
+                        if (token != null)
+                            return token;
                         return '';
                     },
                     'If-Match': function() {


### PR DESCRIPTION
It is no longer needed to base64 encode the token and send it with basic auth, it can be sent directly with the Authorization header.

But someone please check this code, I am not sure if this is valid javascript^^